### PR TITLE
Introduced default and script timeouts to work better with slow speed of AAT

### DIFF
--- a/e2e/cucumber.conf.js
+++ b/e2e/cucumber.conf.js
@@ -1,0 +1,2 @@
+const { setDefaultTimeout } = require('cucumber');
+setDefaultTimeout(60 * 1000);

--- a/e2e/features.conf.js
+++ b/e2e/features.conf.js
@@ -9,7 +9,7 @@ exports.config = {
 
   baseUrl: serviceConfig.CcdWebUrl,
   specs: ['./features/**/*.feature'],
-
+  allScriptsTimeout: 60000,
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
@@ -47,7 +47,10 @@ exports.config = {
   frameworkPath: require.resolve('protractor-cucumber-framework'),
 
   cucumberOpts: {
-    require: ['./features/step_definitions/**/*.steps.ts'],
+    require: [
+      './cucumber.conf.js',
+      './features/step_definitions/**/*.steps.ts'
+    ],
     tags: false,
     profile: false,
     'no-source': true

--- a/e2e/features/step_definitions/authentication.steps.ts
+++ b/e2e/features/step_definitions/authentication.steps.ts
@@ -5,7 +5,7 @@ import { Given } from 'cucumber';
 const anyCcdPage = new AnyCcdPage();
 const authenticationFlow = new AuthenticationFlow();
 
-Given(/^I am signed in as a Case Officer$/, {timeout: 30 * 1000}, async function () {
+Given(/^I am signed in as a Case Officer$/, async function () {
     await authenticationFlow.signInAsCaseOfficer();
     await anyCcdPage.waitUntilLoaded();
 });

--- a/e2e/features/step_definitions/bulk-scanning.steps.ts
+++ b/e2e/features/step_definitions/bulk-scanning.steps.ts
@@ -40,7 +40,7 @@ async function checkDataItems() {
     }
 }
 
-Given(/^I have a bulk-scanned document with (?:all fields)$/, {timeout: 240 * 1000}, async function () {
+Given(/^I have a bulk-scanned document with (?:all fields)$/, {timeout: 600 * 1000}, async function () {
     await anyCcdPage.click('Create new case');
     expect(await anyCcdPage.pageHeadingContains('Create Case')).to.equal(true);
     await anyCcdFormPage.setCreateCaseFieldValue('Case type', 'SSCS Bulkscanning v1.0.1_AAT');
@@ -61,7 +61,7 @@ Given(/^I have a bulk-scanned document with (?:all fields)$/, {timeout: 240 * 10
     await checkDataItems()
 });
 
-When(/^I choose the next step "(.+)"$/, {timeout: 30 * 1000}, async function (action) {
+When(/^I choose the next step "(.+)"$/, async function (action) {
     switch (action) {
         case 'Create new case from exception':
             await caseDetailsPage.doNextStep(action);


### PR DESCRIPTION
This change improves reliability when used with CCD AAT, where response speeds are significantly slower than on local machine.