### PR TITLE
SSCS-8143 - E2E tests run prod tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ setting the environment variables `TEST_CASEOFFICER_USERNAME` and `TEST_CASEOFFI
 $ TEST_CASEOFFICER_USERNAME=? TEST_CASEOFFICER_PASSWORD=? yarn e2e
  ```
 
+#### Running the tests against a local prod ccd version
+ ```bash
+$ ./bin/local-prod-test.sh
+ ```
+
 If you wish to see the browser running the tests simply set the `TEST_E2E_HEADLESS` environment variable to *false*
 ### Updating the project for your service
 
@@ -45,7 +50,7 @@ You need to make changes everywhere there is a `TODO:` comment to make it releva
 * Jenkinsfile_nightly
 * service.conf.js
 
-i.e. changing running enviroment from local to demo or to aat. To run it locally, you need to set docker and other relevant services. Please read ...... (COMIN SOON) .... to set up the local enviroment.
+i.e. changing running environment from local to demo or to aat. To run it locally, you need to set docker and other relevant services. Please read ...... (COMIN SOON) .... to set up the local enviroment.
 
 ## Other tasks
 

--- a/bin/local-prod-test.sh
+++ b/bin/local-prod-test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "\nCreating local prod ccd definition\n"
+cd ../sscs-ccd-definitions/benefit
+docker build -t hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:dev -f ../docker/importer.Dockerfile .
+cd ..
+./bin/create-xlsx.sh benefit dev local prod
+
+echo "\nUploading local prod ccd definition\n"
+cd ../sscs-docker
+./bin/ccd-import-definition.sh ../sscs-ccd-definitions/releases/CCD_SSCSDefinition_vdev_LOCAL.xlsx
+
+
+echo "\nRunning tests against local prod ccd definition\n"
+cd ../sscs-ccd-e2e-tests
+TEST_E2E_USE_PROXY=false TEST_E2E_URL_GATEWAY='http://localhost:3453' TEST_E2E_URL_WEB='http://localhost:3451' TEST_JUDGE_USERNAME='judge@example.com' TEST_JUDGE_PASSWORD='Pa55word11' TEST_DWP_USERNAME='dwpuser@example.com' TEST_DWP_PASSWORD='Pa55word11' TEST_CASEOFFICER_USERNAME='local.test@example.com' TEST_CASEOFFICER_PASSWORD='Pa55word11' yarn test:prod
+
+echo "\nComplete\n"

--- a/e2e/features/alternate-happy-path.feature
+++ b/e2e/features/alternate-happy-path.feature
@@ -10,7 +10,7 @@ Feature: The alternate happy path
     When I switch to be a DWPResponse Writer
     When I choose "Upload response"
     And I upload contains further information "YES"
-    Then the case should end "Response received" state
+    Then the case should be in "Response received" appeal status
 
     When I switch to be a Case Officer
     When I choose "Response reviewed"

--- a/e2e/features/createbundle.feature
+++ b/e2e/features/createbundle.feature
@@ -10,7 +10,7 @@ Feature: Create bundle for a case
     When I switch to be a Case Officer
     When I choose "Upload response"
     And I upload contains further information "NO"
-    Then the case should end "Response received" state
+    Then the case should end "Ready to list" state
 
     When I switch to be a Case Officer
     When I choose the next step "Create a bundle"

--- a/e2e/features/happy-path-user.feature
+++ b/e2e/features/happy-path-user.feature
@@ -10,4 +10,4 @@ Feature: The happy path
     When I switch to be a Case Officer
     When I choose "Upload response"
     And I upload contains further information "NO"
-    Then the case should end "Response received" state
+    Then the case should end "Ready to list" state

--- a/e2e/features/interloc-review.feature
+++ b/e2e/features/interloc-review.feature
@@ -10,15 +10,15 @@ Feature: The interloc review
     When I switch to be a DWPResponse Writer
     When I choose "Upload response"
     And I upload contains further information "YES"
-    Then the case should end "Response received" state
+    Then the case should be in "Response received" appeal status
 
     When I switch to be a Case Officer
     When I choose "Response reviewed"
     And I choose Requires Interlocutory Review Yes "Response reviewed"
     And I submit "Response reviewed"
-    Then the case should end "Response received" state
+    Then the case should be in "Response received" appeal status
 
     When I choose "Action direction"
     And I set DWP State to No action "Action direction"
     And I submit "Action direction"
-    Then the case should end "Response received" state
+    Then the case should be in "Response received" appeal status

--- a/e2e/features/step_definitions/dwp-upload-response.steps.ts
+++ b/e2e/features/step_definitions/dwp-upload-response.steps.ts
@@ -33,8 +33,8 @@ When(/^I upload UC further information with disputed (.+) disputed by others (.+
 });
 
 Then(/^the case should end "(.+)" state$/, async function (state) {
-    await anyCcdPage.reloadPage();
     await anyCcdPage.click('History');
+    await anyCcdPage.reloadPage();
     await browser.sleep(10000);
     expect(await caseDetailsPage.isFieldValueDisplayed('End state', state)).to.equal(true);
     await browser.sleep(500);

--- a/e2e/features/step_definitions/interloc-review.steps.ts
+++ b/e2e/features/step_definitions/interloc-review.steps.ts
@@ -5,11 +5,11 @@ const anyCcdPage = new AnyCcdPage();
 
 When(/^I choose Requires Interlocutory Review Yes "(.+)"$/, async function (action) {
     await anyCcdPage.clickElementById('isInterlocRequired-Yes');
-    anyCcdPage.chooseOptionByElementId('selectWhoReviewsCase', 'Review by Judge');
+    await anyCcdPage.chooseOptionByElementId('selectWhoReviewsCase', 'Review by Judge');
     await anyCcdPage.click('Continue');
 });
 
 When(/^I set DWP State to No action "(.+)"$/, async function (action) {
-    anyCcdPage.chooseOptionByElementId('dwpState', 'No action');
+    await anyCcdPage.chooseOptionByElementId('dwpState', 'No action');
     await anyCcdPage.click('Continue');
 });

--- a/e2e/features/step_definitions/lapse-case.steps.ts
+++ b/e2e/features/step_definitions/lapse-case.steps.ts
@@ -7,7 +7,7 @@ const lapsecase = new LapseCasePage();
 
 When(/^I set DWP State to Lapsed "(.+)"$/, async function (action) {
     await lapsecase.uploadResponse(action);
-    anyCcdPage.chooseOptionByElementId('dwpState', 'No action');
-    anyCcdPage.chooseOptionByElementId('interlocReviewState', 'N/A');
+    await anyCcdPage.chooseOptionByElementId('dwpState', 'No action');
+    await anyCcdPage.chooseOptionByElementId('interlocReviewState', 'N/A');
     await anyCcdPage.click('Continue');
 });

--- a/e2e/features/step_definitions/response-reviewed.steps.ts
+++ b/e2e/features/step_definitions/response-reviewed.steps.ts
@@ -12,11 +12,8 @@ When(/^I choose Requires Interlocutory Review No "(.+)"$/, async function (actio
 });
 
 When(/^I submit "(.+)"$/, async function (action) {
-    console.log("checking heading")
     expect(await anyCcdPage.pageHeadingContains(action)).to.equal(true);
-    console.log("clicking Submit")
     await anyCcdPage.click('Submit');
-    console.log("clicked Submit")
 });
 
 When(/I review the UC received Response$/, async function() {

--- a/e2e/features/step_definitions/response-reviewed.steps.ts
+++ b/e2e/features/step_definitions/response-reviewed.steps.ts
@@ -12,8 +12,11 @@ When(/^I choose Requires Interlocutory Review No "(.+)"$/, async function (actio
 });
 
 When(/^I submit "(.+)"$/, async function (action) {
+    console.log("checking heading")
     expect(await anyCcdPage.pageHeadingContains(action)).to.equal(true);
+    console.log("clicking Submit")
     await anyCcdPage.click('Submit');
+    console.log("clicked Submit")
 });
 
 When(/I review the UC received Response$/, async function() {

--- a/e2e/pages/lapsecase.page.ts
+++ b/e2e/pages/lapsecase.page.ts
@@ -13,8 +13,8 @@ export class LapseCasePage extends AnyPage {
         await this.uploadFile('dwpLT203_documentLink', 'issue1.pdf');
         await this.uploadFile('dwpLapseLetter_documentLink', 'issue2.pdf');
 
-        anyCcdPage.chooseOptionByElementId('dwpState', 'No action');
-        anyCcdPage.chooseOptionByElementId('interlocReviewState', 'N/A');
+        await anyCcdPage.chooseOptionByElementId('dwpState', 'No action');
+        await anyCcdPage.chooseOptionByElementId('interlocReviewState', 'N/A');
     }
 
     async uploadFile(inputElement: string, fileName: string) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "e2e": "yarn test:fullfunctional",
     "test:fullfunctional": "yarn install && protractor ./e2e/features.parallel.conf.js --cucumberOpts.tags=@nightly-test",
+    "test:prod": "yarn install && protractor ./e2e/features.parallel.conf.js --cucumberOpts.tags=@nightly-test --cucumberOpts.tags=~@issue-decision --cucumberOpts.tags=~@uc --cucumberOpts.tags=~@reinstatement --cucumberOpts.tags=~@bundle",
     "test:nsp": "nsp check"
   },
   "dependencies": {


### PR DESCRIPTION
# SSCS-8143 - E2E tests run prod tests locally

- Bash script created to run e2e tests locally `./bin/local-prod-test.sh`
- Tags excluded in test:prod script ->
   - `@issue-decision` - did not work in prod like ccd 
   - `@uc` - excluded from prod like ccd until end of Q1 2021
   - `@reinstatement` - did not work in prod like ccd 
   - `@bundle` - there seems to be a problem on local docker with bundling
- Other issues found and corrected
   - History tab does not appear to non caseworker users so had to change `the case should end "state" state` to `the case should be in "state" appeal status`
   - `the case should end "Response received" state` doesn't occur it ends up in the Ready to list state
   - some commands didn't start with `await` so the tests failed. 

