### PR TITLE
SSCS-9680 - fix e2e tests for process audio video evidence

### DIFF
--- a/e2e/features/step_definitions/process-audio-video-evidence.steps.ts
+++ b/e2e/features/step_definitions/process-audio-video-evidence.steps.ts
@@ -37,7 +37,7 @@ When(/^I process the AV evidence using the "(.+)" action$/, async function (acti
     await anyCcdPage.click('Continue');
     expect(await anyCcdPage.contentContains('Selected Audio/Video Evidence Details')).to.equal(true);
     await anyCcdPage.chooseOptionContainingText('#processAudioVideoAction', action);
-    await element(by.id('bodyContent')).sendKeys('Body test content');
+    await element(by.id('directionNoticeContent')).sendKeys('Body test content');
     await element(by.id('signedBy')).sendKeys('Signed by test content');
     await element(by.id('signedRole')).sendKeys('Signed role test content');
     await anyCcdPage.click('Continue');


### PR DESCRIPTION
SSCS-9680 - fix e2e tests for process audio video evidence

The field bodyContent has been changed for the process audio video event. 
A new field has been added so that the we can change the label. It is now called directionNoticeContent.