### PR TITLE
run e2e tests locally

### DIFF
--- a/e2e/pages/idam-sign-in.page.ts
+++ b/e2e/pages/idam-sign-in.page.ts
@@ -9,7 +9,7 @@ export class IdamSignInPage extends AnyPage {
 
     private username = 'form[name="loginForm"] input#username';
     private password = 'form[name="loginForm"] input#password';
-    private signInButton = 'form[name="loginForm"] input[type=submit]';
+    private signInButton = 'form[name="loginForm"] *[type=submit]';
 
     async signIn(
         emailAddress: string,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "postinstall": "webdriver-manager update --gecko=false",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "e2e": "yarn test:fullfunctional",
+    "test:local": "yarn install && cross-env TEST_E2E_URL_GATEWAY='http://localhost:5000' TEST_E2E_URL_WEB='http://localhost:3455' TEST_E2E_API_URI=http://localhost:8080 TEST_JUDGE_USERNAME='judge@example.com' TEST_JUDGE_PASSWORD='Pa55word11' TEST_DWP_USERNAME='dwpuser@example.com' TEST_DWP_PASSWORD='Pa55word11' TEST_CASEOFFICER_USERNAME='local.test@example.com' TEST_CASEOFFICER_PASSWORD='Pa55word11' protractor ./e2e/features.parallel.conf.js --cucumberOpts.tags=nightly-test",
     "test:aat": "yarn install && cross-env TRIBUNALS_API_URL=http://sscs-tribunals-api-aat.service.core-compute-aat.internal TEST_JUDGE_USERNAME='sscs.judge.user@mailinator.com' TEST_JUDGE_PASSWORD='Testing123' TEST_DWP_USERNAME='sscs.dwp.user@mailinator.com' TEST_DWP_PASSWORD='Testing123' TEST_CASEOFFICER_USERNAME='sscs.superuser@mailinator.com' TEST_CASEOFFICER_PASSWORD='Testing123' protractor ./e2e/features.parallel.conf.js --cucumberOpts.tags=@nightly-test",
     "test:fullfunctional": "yarn install && protractor ./e2e/features.parallel.conf.js --cucumberOpts.tags=@nightly-test",
     "test:previewfunctional": "yarn install && protractor ./e2e/features.parallel.conf.js --cucumberOpts.tags=@preview-test",


### PR DESCRIPTION
This PR gives the user the option to run the e2e tests locally as well as having the current option to run them in AAT.
The idam-simulator has a button instead of an input for the login page.